### PR TITLE
Auth token provided must be from upload URL

### DIFF
--- a/examples/b2_upload_file.php
+++ b/examples/b2_upload_file.php
@@ -9,7 +9,7 @@ $file_path  = ""; // Path to the file you wish to upload
 $b2 = new b2_api; // Create a new instance of b2_api
 $auth = $b2->b2_authorize_account($account_id, $app_key); // Runs b2_authorize_account
 $url = $b2->b2_get_upload_url($auth->apiUrl, $auth->accountId, $auth->authorizationToken, $bucket_id); // Runs b2_get_upload_url
-$output = $b2->b2_upload_file($url->uploadUrl, $auth->authorizationToken, $file_path); // Runs b2_get_upload_url
+$output = $b2->b2_upload_file($url->uploadUrl, $url->authorizationToken, $file_path); // Runs b2_get_upload_url
 
 echo "b2_upload_file\n\n";
 var_dump($output);


### PR DESCRIPTION
The example upload script has a bug which will always result in "invalid auth token" error when trying to upload since the auth token is taken from the initial login, not from the upload URL
